### PR TITLE
Fix bottom of Backstab card

### DIFF
--- a/src/constants/ABILITY_CARD/CONFIG/Scoundrel/index.js
+++ b/src/constants/ABILITY_CARD/CONFIG/Scoundrel/index.js
@@ -149,7 +149,7 @@ export default {
       consumed: true,
     },
     bottom: {
-      actions: [{ action: ACTION.ATTACK, value: 6 }],
+      actions: [{ action: ACTION.MOVE, value: 6 }],
     },
   },
   92: {


### PR DESCRIPTION
The card says "Move 6", but the action is set to Attack in the constants file.